### PR TITLE
Allows version downgrades

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -8,7 +8,7 @@ SPARKLE_APPEND_VERSION_NUMBER = 1
 
 // Sparkle usually doesn't allow downgrades as they're usually accidental, but
 // if your app has a downgrade function or URL handler, turn this on
-SPARKLE_AUTOMATED_DOWNGRADES = 0
+SPARKLE_AUTOMATED_DOWNGRADES = 1
 
 // If your app file on disk is named "MyApp 1.1b4", Sparkle usually updates it
 // in place, giving you an app named 1.1b4 that is actually 1.2. Turn the


### PR DESCRIPTION
In pro, the server sends back only available upgrades so we know the one about to be installed is valid, so no need for sparkle to handle validating the new download